### PR TITLE
Fix dark/light mode live switch leaving stale widget colours

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -30,6 +30,19 @@ static void applyTheme(QApplication &a, bool dark)
     styles.replace("@PROGRESS_BG",     dark ? "#3A3A3A" : "#E0E0E0");
     styles.replace("@PROGRESS_TEXT",   dark ? "#CCCCCC" : "#555555");
     a.setStyleSheet(styles);
+
+    // Qt sends QEvent::StyleChange to all widgets when the application stylesheet
+    // changes, but some platform backends cache palette-derived colours (e.g.
+    // palette(window) values and widget-level stylesheet combinations) and do not
+    // fully repaint on a live scheme switch.  Walking every widget with an explicit
+    // unpolish → polish → update cycle discards those stale caches and guarantees
+    // that every widget repaints exactly as it would on a cold start.
+    // At launch this loop is a no-op because no widgets have been created yet.
+    for (QWidget *w : QApplication::allWidgets()) {
+        w->style()->unpolish(w);
+        w->style()->polish(w);
+        w->update();
+    }
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
After a runtime OS colour-scheme change applyTheme() called QApplication::setStyleSheet(), which sends QEvent::StyleChange to all widgets but does not invalidate every widget's cached palette data. Platform backends and Qt's stylesheet engine can cache resolved colours (palette(window) lookups, widget-level stylesheet combinations such as the embedded QProgressBar in MultiProgressBar) and skip a full repaint.

Add an explicit unpolish → polish → update walk over QApplication::allWidgets() after the new stylesheet is applied.  This discards all cached colour state and guarantees every widget repaints exactly as it would on a cold start.  The loop is a no-op at launch because no widgets have been created yet when applyTheme() is first called.