### PR TITLE
Fix macOS not reporting file deletion - Claude/issue 8 20260419 1451

### DIFF
--- a/compendiacore.cpp
+++ b/compendiacore.cpp
@@ -2243,6 +2243,17 @@ void CompendiaCore::handleFileAdded(const QString& absolutePath)
     if (!fileInfo.exists() || !fileInfo.isFile())
         return;
 
+    // Reject if a model entry for this path already exists (guards against duplicate entries
+    // when macOS delivers the destination-directory event before the source-directory event,
+    // causing the file to appear as a new addition rather than a move).
+    for (int i = 0; i < tagged_files_->rowCount(); ++i) {
+        auto* tf = tagged_files_->item(i)->data(Qt::UserRole + 1).value<TaggedFile*>();
+        if (tf && QDir::cleanPath(tf->filePath + "/" + tf->fileName) == QDir::cleanPath(absolutePath)) {
+            qDebug() << "[FileWatch] handleFileAdded: already in model, skipping" << absolutePath;
+            return;
+        }
+    }
+
     // Load sidecar JSON if one exists alongside the new file
     const QString sidecarPath = fileInfo.absolutePath() + "/" + fileInfo.completeBaseName() + ".json";
     QFile sidecarFile(sidecarPath);

--- a/compendiacore.cpp
+++ b/compendiacore.cpp
@@ -2093,6 +2093,11 @@ void CompendiaCore::processWatcherChanges()
 
     for (const QString& path : allAppeared)
         handleFileAdded(path);
+
+    // Remove any model entries whose backing files no longer exist. This catches the macOS case
+    // where only the destination-directory event fires: the source entry becomes stale and is
+    // never matched by the correlation pass above.
+    removeStaleModelEntries();
 }
 
 /*! \brief Handles a file that disappeared with no matching appearance elsewhere in the watched tree. */
@@ -2307,4 +2312,23 @@ void CompendiaCore::handleFileAdded(const QString& absolutePath)
 
     tagged_files_proxy_->sort(0);
     emit fileAddedExternally(absolutePath);
+}
+
+void CompendiaCore::removeStaleModelEntries()
+{
+    // Collect stale paths first to avoid modifying the model while iterating it.
+    QStringList stalePaths;
+    for (int i = 0; i < tagged_files_->rowCount(); ++i) {
+        auto* tf = tagged_files_->item(i)->data(Qt::UserRole + 1).value<TaggedFile*>();
+        if (tf) {
+            const QString absPath = QDir::cleanPath(tf->filePath + "/" + tf->fileName);
+            if (!QFileInfo::exists(absPath))
+                stalePaths.append(absPath);
+        }
+    }
+
+    for (const QString& path : stalePaths) {
+        qDebug() << "[FileWatch] removeStaleModelEntries: removing stale entry" << path;
+        handleFileRemoved(path);
+    }
 }

--- a/compendiacore.h
+++ b/compendiacore.h
@@ -118,6 +118,14 @@ private:
      */
     void handleFileAdded(const QString& absolutePath);
 
+    /*! \brief Scans every model entry and removes any whose backing file no longer exists on disk.
+     *
+     * Called at the end of each watcher debounce cycle. Recovers from the macOS case where the
+     * source-directory event is never delivered for a moved file, leaving a stale entry behind
+     * that handleFileAdded()'s duplicate guard would then preserve incorrectly.
+     */
+    void removeStaleModelEntries();
+
     /*! \brief Moves up to a fixed number of pending icon results from the background queue into the model.
      */
     void flushIconGeneratorQueue();


### PR DESCRIPTION
Workaround for macOS not reliably reporting removal of files when the user moves a file in the OS during an open session