### PR TITLE
Keep tag library in stable order; sort on load and via Sort button / …

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -125,6 +125,17 @@ MainWindow::MainWindow(QWidget *parent)
         ui->menuEdit->addAction(redoAct);
     }
 
+    // Sort Library — shared with the Sort button above the tag library panel
+    {
+        ui->menuEdit->addSeparator();
+        QAction* sortAct = new QAction(tr("Sort Library"), this);
+        connect(sortAct, &QAction::triggered, this, &MainWindow::sortTagLibrary);
+        ui->menuEdit->addAction(sortAct);
+    }
+
+    connect(ui->sortLibraryButton, &QPushButton::clicked,
+            this, &MainWindow::sortTagLibrary);
+
     connect(core, &CompendiaCore::fileRemovedExternally,
             this, [this](TaggedFile* tf, bool, bool) {
         progress_->showNotification("Removed: " + tf->fileName);
@@ -708,6 +719,7 @@ void MainWindow::loadFolder(const QString &folder, bool skipCacheConfirm)
     ui->navFilterContainer->activateWelcome();
     ui->fileListTagAssignmentContainer->activateWelcome();
 
+    sortLibraryOnNextRefresh_ = true;
     refreshNavTagLibrary();
     refreshTagAssignmentArea();
     clearPreview();
@@ -725,6 +737,13 @@ void MainWindow::refreshNavTagLibrary(){
 
     QSet<Tag*>* libTags = core->getLibraryTags();
     ui->navLibraryContainer->refresh(libTags);
+
+    // On the first non-empty refresh after a folder load, sort once so the
+    // starting view is alphabetical even though auto-sort is disabled.
+    if (sortLibraryOnNextRefresh_ && !libTags->isEmpty()) {
+        sortTagLibrary();
+        sortLibraryOnNextRefresh_ = false;
+    }
 
     // Dismiss all welcome hints the moment the first tag exists, regardless of
     // which code path created it (tag dialog, face detection, drag-drop, etc.).
@@ -753,6 +772,15 @@ void MainWindow::refreshTagAssignmentArea(){
     ui->fileListTagAssignmentContainer->refresh(assignedTags);
     refreshPreviewTagsLabel();
 
+}
+
+/*! \brief Alphabetizes tag families and tags in the library panel.
+ *
+ * Shared by the Sort button and Edit > Sort Library menu action.
+ */
+void MainWindow::sortTagLibrary()
+{
+    ui->navLibraryContainer->sort();
 }
 
 /*! \brief Rebuilds the tag-region overlays in the preview when a tag is renamed.

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -128,7 +128,7 @@ MainWindow::MainWindow(QWidget *parent)
     // Sort Library — shared with the Sort button above the tag library panel
     {
         ui->menuEdit->addSeparator();
-        QAction* sortAct = new QAction(tr("Sort Library"), this);
+        QAction* sortAct = new QAction(tr("Sort Tag Library"), this);
         connect(sortAct, &QAction::triggered, this, &MainWindow::sortTagLibrary);
         ui->menuEdit->addAction(sortAct);
     }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -45,6 +45,7 @@ private:
     QTimer* rectWarmupTimer_ = nullptr;       ///< Debounce timer for post-rect-adjust face cache warming.
     TaggedFile* warmupPendingFile_ = nullptr; ///< File waiting for rect-adjust warmup when the timer fires.
     bool preReleaseWarningAccepted_ = false;  ///< True once the user has accepted the pre-release warning this session.
+    bool sortLibraryOnNextRefresh_ = false;   ///< Set by loadFolder(); consumed by the first non-empty refreshNavTagLibrary() to sort on load.
 
 public:
     /*! \brief Constructs the main window, sets up layouts, status bar, and default pane sizes.
@@ -167,6 +168,9 @@ private:
 
     /*! \brief Starts the Save progress bar and writes metadata for all dirty files. */
     void saveAll();
+
+    /*! \brief Alphabetizes tag families and tags in the library panel. Shared by the Sort button and Edit menu. */
+    void sortTagLibrary();
 
     /*! \brief Sets the folder filter to \p folderPath and enables both clear-isolation actions. */
     void applyFolderIsolation(const QString& folderPath);

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -194,17 +194,49 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QLineEdit" name="tagSearchLineEdit">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>24</height>
-            </size>
+          <layout class="QHBoxLayout" name="tagLibraryHeaderLayout">
+           <property name="spacing">
+            <number>4</number>
            </property>
-           <property name="placeholderText">
-            <string>Search tags</string>
-           </property>
-          </widget>
+           <item>
+            <widget class="QLineEdit" name="tagSearchLineEdit">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>24</height>
+              </size>
+             </property>
+             <property name="placeholderText">
+              <string>Search tags</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="sortLibraryButton">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>24</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>24</height>
+              </size>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Sort</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
          <item>
           <widget class="QScrollArea" name="navLibraryScrollArea">

--- a/navlibrarycontainer.cpp
+++ b/navlibrarycontainer.cpp
@@ -10,6 +10,7 @@ NavLibraryContainer::NavLibraryContainer(QWidget *parent)
     setAcceptsClickToDismiss(true);
     setHint(QStringLiteral(":/resources/bookshelf-hint.svg"), 66, 64);
     setAutoFillBackground(false);
+    setAutoSortOnRefresh(false);
 }
 
 /*! \brief Overrides the Qt base-class mouse-release handler to create a new tag family on click.

--- a/tagcontainer.cpp
+++ b/tagcontainer.cpp
@@ -1,5 +1,6 @@
 #include "tagcontainer.h"
 #include <QLayout>
+#include <algorithm>
 
 /*! \brief Constructs an empty TagContainer.
  *
@@ -8,6 +9,16 @@
 TagContainer::TagContainer(QWidget *parent)
     : QWidget{parent}
 {}
+
+/*! \brief Controls whether refresh() auto-sorts alphabetically on every call.
+ *
+ * Set to false on the library container so insertion order is preserved.
+ * Defaults to true so assignment and filter containers stay alphabetical.
+ */
+void TagContainer::setAutoSortOnRefresh(bool autoSort)
+{
+    autoSortOnRefresh_ = autoSort;
+}
 
 /*! \brief Rebuilds the widget hierarchy to display exactly the given set of tags.
  *
@@ -23,58 +34,63 @@ void TagContainer::refresh(QSet<Tag*>* tags){
 
     clear();
 
-    // Insert all tags in the incoming set, resolving into families
-    QSetIterator<Tag *> i(*tags);
-    while (i.hasNext()) {
-        Tag* currentTag = i.next();
-        TagFamily* currentTagFamily = currentTag->tagFamily;
+    // Build lookup: family -> its tags in this refresh pass.
+    QMap<TagFamily*, QList<Tag*>> incoming;
+    for (Tag* tag : *tags)
+        incoming[tag->tagFamily].append(tag);
 
-        TagFamilyWidget* w = nullptr;
-        TagWidget* tw = nullptr;
+    // Update family_order_: remove absent families, append new ones at the end.
+    family_order_.removeIf([&incoming](TagFamily* f){ return !incoming.contains(f); });
+    for (TagFamily* fam : incoming.keys()) {
+        if (!family_order_.contains(fam))
+            family_order_.append(fam);
+    }
 
-        // If there are no tag family widgets or there's no tagfamilywidget for the current tag's family, add a new tagfamilywidget
-        QList<TagFamilyWidget*> existingTFWidgets = findChildren<TagFamilyWidget*>();
-
-        for(int tfwi = 0; tfwi < existingTFWidgets.count(); ++tfwi){
-            TagFamilyWidget* existingTFWidget = existingTFWidgets.at(tfwi);
-
-            if (existingTFWidget->getTagFamily() == currentTagFamily) {
-                // Tag family widget exists, use it
-                w = existingTFWidget;
-            }
+    // Update tag_order_ for each tracked family.
+    for (TagFamily* fam : family_order_) {
+        QList<Tag*>& order = tag_order_[fam];
+        const QList<Tag*>& incomingTags = incoming[fam];
+        order.removeIf([&incomingTags](Tag* t){ return !incomingTags.contains(t); });
+        for (Tag* tag : incomingTags) {
+            if (!order.contains(tag))
+                order.append(tag);
         }
+    }
+    // Drop stale family entries from tag_order_.
+    for (TagFamily* fam : tag_order_.keys()) {
+        if (!family_order_.contains(fam))
+            tag_order_.remove(fam);
+    }
 
-        if (w==nullptr){
-            w = new TagFamilyWidget(currentTag->tagFamily, this);
-            layout()->addWidget(w);
-            w->show();
-        }
+    // Sort tracking lists alphabetically when auto-sort is on.
+    if (autoSortOnRefresh_) {
+        std::sort(family_order_.begin(), family_order_.end(),
+                  [](TagFamily* a, TagFamily* b){ return a->getName() < b->getName(); });
+        for (QList<Tag*>& tagList : tag_order_)
+            std::sort(tagList.begin(), tagList.end(),
+                      [](Tag* a, Tag* b){ return a->getName() < b->getName(); });
+    }
 
-        // If there are no tag widgets, or there's no tagwidget for the current tag in the current family widget, add a new tagwidget
-        QList<TagWidget*> existingTWidgets = w->findChildren<TagWidget*>();
+    // Build widgets in tracked order.
+    for (TagFamily* fam : family_order_) {
+        TagFamilyWidget* w = new TagFamilyWidget(fam, this);
+        layout()->addWidget(w);
+        w->show();
 
-        for(int twi = 0; twi < existingTWidgets.count(); ++twi){
-            TagWidget* existingTWidget = existingTWidgets.at(twi);
-            if(existingTWidget->getTag() == currentTag){
-                // Tag widget exists, use it
-                tw = existingTWidget;
-            }
-        }
-
-        if (tw==nullptr){
-            tw = new TagWidget(currentTag, w);
-            if (! connect(tw, &TagWidget::deleteRequested, this, &TagContainer::onTagDeleteRequested))
+        for (Tag* tag : tag_order_[fam]) {
+            TagWidget* tw = new TagWidget(tag, w);
+            if (!connect(tw, &TagWidget::deleteRequested, this, &TagContainer::onTagDeleteRequested))
                 qWarning() << "Failed to connect tag widget delete to container delete";
             connect(tw, &TagWidget::tagNameChanged, this, &TagContainer::tagNameChanged);
-            connect(tw, &TagWidget::tagNameChanged, w, [w](Tag*){ w->sort(); });
+            if (autoSortOnRefresh_)
+                connect(tw, &TagWidget::tagNameChanged, w, [w](Tag*){ w->sort(); });
             connect(tw, &TagWidget::widthChangedDuringEdit, w, &TagFamilyWidget::onChildTagWidthChanged);
             w->layout()->addWidget(tw);
             tw->show();
-
-            // Cause the family to grow if there are more tags than space in the family widget
             w->refreshMinimumHeight();
         }
     }
+
     // Restore collapsed state for newly created widgets.
     const QList<TagFamilyWidget*> created =
         findChildren<TagFamilyWidget*>(QString(), Qt::FindDirectChildrenOnly);
@@ -83,8 +99,6 @@ void TagContainer::refresh(QSet<Tag*>* tags){
         if (collapsed_state_.contains(name))
             fw->setCollapsed(collapsed_state_.value(name));
     }
-
-    this->sort();
 }
 
 /*! \brief Removes all child TagFamilyWidget and TagWidget items from the layout. */
@@ -147,29 +161,32 @@ void TagContainer::filter(const QString &text) {
 /*! \brief Sorts all TagFamilyWidget children alphabetically by family name,
  *  and sorts tags within each family alphabetically by tag name. */
 void TagContainer::sort() {
+    // Sort tracking lists alphabetically.
+    std::sort(family_order_.begin(), family_order_.end(),
+              [](TagFamily* a, TagFamily* b){ return a->getName() < b->getName(); });
+    for (QList<Tag*>& tagList : tag_order_)
+        std::sort(tagList.begin(), tagList.end(),
+                  [](Tag* a, Tag* b){ return a->getName() < b->getName(); });
+
+    // Pull all TagFamilyWidgets out of the layout.
     QList<TagFamilyWidget*> fwlist;
     QLayoutItem* item = nullptr;
-
-    // Temporarily move child widgets to a list
     while ((item = layout()->takeAt(0)) != nullptr) {
-        if (QWidget *widget = item->widget()) {
-            if (auto *tfw = qobject_cast<TagFamilyWidget*>(widget)) {
+        if (QWidget *widget = item->widget())
+            if (auto *tfw = qobject_cast<TagFamilyWidget*>(widget))
                 fwlist.append(tfw);
-            }
-        }
-        delete item; // is this needed to avoid QLayoutItem leak?
+        delete item;
     }
 
-    // Sort the list (compare pointers)
-    std::sort(fwlist.begin(), fwlist.end(),
-              [](TagFamilyWidget* a, TagFamilyWidget* b) {
-                  return a->getTagFamily()->getName() < b->getTagFamily()->getName();
-              });
-
-    // Put the widgets back in the layout, in order
-    for (TagFamilyWidget* w : fwlist) {
-        w->sort();
-        layout()->addWidget(w);
-        w->refreshMinimumHeight();
+    // Re-insert them in the order dictated by the now-sorted family_order_.
+    for (TagFamily* fam : family_order_) {
+        for (TagFamilyWidget* w : fwlist) {
+            if (w->getTagFamily() == fam) {
+                w->sort();
+                layout()->addWidget(w);
+                w->refreshMinimumHeight();
+                break;
+            }
+        }
     }
 }

--- a/tagcontainer.h
+++ b/tagcontainer.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QWidget>
 #include <QLayout>
+#include <QList>
 #include <QMap>
 #include <QSet>
 #include "tagwidget.h"
@@ -25,13 +26,16 @@ private:
     /// Collapsed state keyed by family name; persisted across refresh() calls.
     QMap<QString, bool> collapsed_state_;
 
-    /*! \brief Comparison helper for sorting TagFamilyWidgets by family name.
-     *
-     * \param a First TagFamilyWidget to compare.
-     * \param b Second TagFamilyWidget to compare.
-     * \return True if a's family name is less than b's.
-     */
-    bool const famNameLessThan(const TagFamilyWidget &a, const TagFamilyWidget &b) ;
+    /// Display order for tag families; new families append at end.
+    QList<TagFamily*> family_order_;
+
+    /// Display order for tags within each family; new tags append at end.
+    QMap<TagFamily*, QList<Tag*>> tag_order_;
+
+    /// When true, refresh() sorts alphabetically; when false, insertion order is preserved.
+    bool autoSortOnRefresh_ = true;
+
+    bool const famNameLessThan(const TagFamilyWidget &a, const TagFamilyWidget &b);
 
 public:
     /*! \brief Constructs an empty TagContainer.
@@ -58,6 +62,9 @@ public:
     /*! \brief Sorts all TagFamilyWidget children alphabetically by family name,
      *  and sorts tags within each family alphabetically by tag name. */
     void sort();
+
+    /*! \brief Controls whether refresh() auto-sorts; pass false to preserve insertion order. */
+    void setAutoSortOnRefresh(bool autoSort);
 
     /*! \brief Shows only tag families and tags whose name starts with \p text.
      *


### PR DESCRIPTION
Improve user experience when making tags by suppressing the automatic sort that would happen on each change, sometimes causing entries to scroll out of view