### PR TITLE
Remove Qt image allocation limit to fix large file preview errors

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,7 @@
 #include <QFile>
 #include <QGuiApplication>
 #include <QIcon>
+#include <QImageReader>
 #include <QStyleHints>
 #include <QTimer>
 
@@ -49,6 +50,7 @@ static void applyTheme(QApplication &a, bool dark)
 int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
+    QImageReader::setAllocationLimit(0);
     a.setWindowIcon(QIcon(":/resources/compendia_icon.svg"));
 
     applyTheme(a, QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark);


### PR DESCRIPTION
Qt 6 defaults to a 256 MB allocation limit for image loading, which causes large .jpg files to be rejected with the error: "QImageIOHandler: Rejecting image as it exceeds the current allocation limit of 256 mb". Setting the limit to 0 disables the restriction.

Fixes #13