### PR TITLE
Add "Untagged Images" filter to show only files with no tags

### DIFF
--- a/compendiacore.cpp
+++ b/compendiacore.cpp
@@ -1547,6 +1547,14 @@ void CompendiaCore::clearIsolationSet() {
     tagged_files_proxy_->clearIsolationSet();
 }
 
+void CompendiaCore::setUntaggedOnly(bool untaggedOnly) {
+    tagged_files_proxy_->setUntaggedOnly(untaggedOnly);
+}
+
+bool CompendiaCore::isUntaggedOnly() const {
+    return tagged_files_proxy_->isUntaggedOnly();
+}
+
 /*! \brief Returns true when an isolation set is active.
  *
  * \return True if the proxy model has a non-empty isolation set.

--- a/compendiacore.h
+++ b/compendiacore.h
@@ -480,6 +480,17 @@ public:
      */
     int isolationSetSize() const;
 
+    /*! \brief Enables or disables the untagged-only filter.
+     *
+     * When enabled, only files with no tags are shown.
+     *
+     * \param untaggedOnly True to show only untagged files; false to disable the filter.
+     */
+    void setUntaggedOnly(bool untaggedOnly);
+
+    /*! \brief Returns true when the untagged-only filter is active. */
+    bool isUntaggedOnly() const;
+
     /*! \brief Returns the underlying QStandardItemModel containing all file items.
      *
      * \return Pointer to the source item model.

--- a/filterproxymodel.cpp
+++ b/filterproxymodel.cpp
@@ -61,7 +61,9 @@ bool FilterProxyModel::passesBaseFilters(TaggedFile* tf) const
         }
     }
 
-    return nameResult && folderResult && tagResult && dateResult && ratingResult;
+    bool untaggedResult = !untagged_only_ || tf->tags()->isEmpty();
+
+    return nameResult && folderResult && tagResult && dateResult && ratingResult && untaggedResult;
 }
 
 /*! \brief Overrides the Qt base-class row-acceptance test to apply all active filters.
@@ -221,4 +223,14 @@ int FilterProxyModel::isolationSetSize() const {
 bool FilterProxyModel::passesNonIsolationFilters(TaggedFile* tf) const
 {
     return passesBaseFilters(tf);
+}
+
+void FilterProxyModel::setUntaggedOnly(bool untaggedOnly) {
+    beginFilterChange();
+    untagged_only_ = untaggedOnly;
+    endFilterChange();
+}
+
+bool FilterProxyModel::isUntaggedOnly() const {
+    return untagged_only_;
 }

--- a/filterproxymodel.h
+++ b/filterproxymodel.h
@@ -36,6 +36,7 @@ private:
     QSet<TaggedFile*> isolation_set_; ///< When non-empty, only listed files can pass.
     std::optional<int> rating_filter_; ///< When set, only files matching the mode+value pass.
     RatingFilterMode rating_filter_mode_ = Exactly; ///< Comparison mode for the rating filter.
+    bool untagged_only_ = false; ///< When true, only files with no tags pass.
 
     /*! \brief Tests \a tf against all base filters (name, folder, tag, date, rating).
      *
@@ -167,6 +168,20 @@ public:
      * \return True if \a tf passes all non-isolation filters.
      */
     bool passesNonIsolationFilters(TaggedFile* tf) const;
+
+    /*! \brief Enables or disables the untagged-only filter and re-applies the filter.
+     *
+     * When enabled, only files with no tags pass. When disabled, all files are eligible.
+     *
+     * \param untaggedOnly True to show only untagged files; false to disable the filter.
+     */
+    void setUntaggedOnly(bool untaggedOnly);
+
+    /*! \brief Returns true when the untagged-only filter is active.
+     *
+     * \return True if only untagged files are shown.
+     */
+    bool isUntaggedOnly() const;
 
 };
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -957,6 +957,10 @@ void MainWindow::on_actionClearAllFilters_triggered()
     // Isolation sets
     clearSelectionIsolation();
 
+    // Untagged-only filter
+    ui->actionUntaggedImages->setChecked(false);
+    core->setUntaggedOnly(false);
+
     refreshTagAssignmentArea();
 }
 
@@ -965,6 +969,15 @@ void MainWindow::on_actionUnreadableFiles_triggered()
 {
     core->isolateUnreadableFiles();
     ui->actionClearIsolation->setEnabled(true);
+    updateFileCountLabel();
+    refreshTagAssignmentArea();
+}
+
+/*! \brief Toggles the untagged-only filter to show only files with no tags. */
+void MainWindow::on_actionUntaggedImages_triggered()
+{
+    bool active = ui->actionUntaggedImages->isChecked();
+    core->setUntaggedOnly(active);
     updateFileCountLabel();
     refreshTagAssignmentArea();
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -445,6 +445,9 @@ private slots:
     /*! \brief Isolates files that could not be opened during icon generation. */
     void on_actionUnreadableFiles_triggered();
 
+    /*! \brief Toggles the untagged-only filter to show only files with no tags. */
+    void on_actionUntaggedImages_triggered();
+
     /*! \brief Drills into the folder of the selected file, reloading with it as the new root. */
     void on_actionDrillToFolder_triggered();
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -899,6 +899,7 @@
     <addaction name="separator"/>
     <addaction name="actionClearAllFilters"/>
     <addaction name="separator"/>
+    <addaction name="actionUntaggedImages"/>
     <addaction name="actionUnreadableFiles"/>
    </widget>
    <widget class="QMenu" name="menuAutos">
@@ -1071,6 +1072,14 @@
    </property>
    <property name="text">
     <string>Unreadable Files</string>
+   </property>
+  </action>
+  <action name="actionUntaggedImages">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Untagged Images</string>
    </property>
   </action>
   <action name="actionAbout">


### PR DESCRIPTION
Adds a checkable Filter > Untagged Images menu action. When checked, only files that have no tags assigned pass the filter. The filter is dynamic: tagging a file while the filter is active will immediately remove it from view. Unchecking or using Clear All resets it.

Closes #12

Generated with [Claude Code](https://claude.ai/code)