### PR TITLE
Fix filter not refreshing when file moved externally

### DIFF
--- a/compendiacore.cpp
+++ b/compendiacore.cpp
@@ -2107,7 +2107,7 @@ void CompendiaCore::processWatcherChanges()
     // would never re-run filterAcceptsRow() and the item would stay visible despite no
     // longer passing the folder filter.
     if (hadMoves)
-        tagged_files_proxy_->invalidateFilter();
+        tagged_files_proxy_->refreshFilter();
 }
 
 /*! \brief Handles a file that disappeared with no matching appearance elsewhere in the watched tree. */

--- a/filterproxymodel.h
+++ b/filterproxymodel.h
@@ -150,6 +150,14 @@ public:
      */
     bool isIsolated() const;
 
+    /*! \brief Forces the proxy to re-evaluate filterAcceptsRow() for every row.
+     *
+     * Exposes the protected QSortFilterProxyModel::invalidateFilter() so that
+     * external code (e.g. CompendiaCore) can trigger a full filter refresh after
+     * in-place model mutations that do not emit dataChanged.
+     */
+    void refreshFilter() { invalidateFilter(); }
+
     /*! \brief Returns the number of files in the current isolation set.
      *
      * \return Size of isolation_set_, or 0 when not isolated.


### PR DESCRIPTION
Fixes #6

Adds a public `refreshFilter()` wrapper on `FilterProxyModel` that exposes the protected `QSortFilterProxyModel::invalidateFilter()`, and calls it after batched file-system changes that include moves so the proxy re-evaluates all rows.

Generated with [Claude Code](https://claude.ai/code)