### PR TITLE
Add "Untagged Images" filter using isolation set

### DIFF
--- a/compendiacore.cpp
+++ b/compendiacore.cpp
@@ -1547,14 +1547,6 @@ void CompendiaCore::clearIsolationSet() {
     tagged_files_proxy_->clearIsolationSet();
 }
 
-void CompendiaCore::setUntaggedOnly(bool untaggedOnly) {
-    tagged_files_proxy_->setUntaggedOnly(untaggedOnly);
-}
-
-bool CompendiaCore::isUntaggedOnly() const {
-    return tagged_files_proxy_->isUntaggedOnly();
-}
-
 /*! \brief Returns true when an isolation set is active.
  *
  * \return True if the proxy model has a non-empty isolation set.

--- a/compendiacore.h
+++ b/compendiacore.h
@@ -480,17 +480,6 @@ public:
      */
     int isolationSetSize() const;
 
-    /*! \brief Enables or disables the untagged-only filter.
-     *
-     * When enabled, only files with no tags are shown.
-     *
-     * \param untaggedOnly True to show only untagged files; false to disable the filter.
-     */
-    void setUntaggedOnly(bool untaggedOnly);
-
-    /*! \brief Returns true when the untagged-only filter is active. */
-    bool isUntaggedOnly() const;
-
     /*! \brief Returns the underlying QStandardItemModel containing all file items.
      *
      * \return Pointer to the source item model.

--- a/filterproxymodel.cpp
+++ b/filterproxymodel.cpp
@@ -61,9 +61,7 @@ bool FilterProxyModel::passesBaseFilters(TaggedFile* tf) const
         }
     }
 
-    bool untaggedResult = !untagged_only_ || tf->tags()->isEmpty();
-
-    return nameResult && folderResult && tagResult && dateResult && ratingResult && untaggedResult;
+    return nameResult && folderResult && tagResult && dateResult && ratingResult;
 }
 
 /*! \brief Overrides the Qt base-class row-acceptance test to apply all active filters.
@@ -225,12 +223,3 @@ bool FilterProxyModel::passesNonIsolationFilters(TaggedFile* tf) const
     return passesBaseFilters(tf);
 }
 
-void FilterProxyModel::setUntaggedOnly(bool untaggedOnly) {
-    beginFilterChange();
-    untagged_only_ = untaggedOnly;
-    endFilterChange();
-}
-
-bool FilterProxyModel::isUntaggedOnly() const {
-    return untagged_only_;
-}

--- a/filterproxymodel.h
+++ b/filterproxymodel.h
@@ -36,7 +36,6 @@ private:
     QSet<TaggedFile*> isolation_set_; ///< When non-empty, only listed files can pass.
     std::optional<int> rating_filter_; ///< When set, only files matching the mode+value pass.
     RatingFilterMode rating_filter_mode_ = Exactly; ///< Comparison mode for the rating filter.
-    bool untagged_only_ = false; ///< When true, only files with no tags pass.
 
     /*! \brief Tests \a tf against all base filters (name, folder, tag, date, rating).
      *
@@ -176,20 +175,6 @@ public:
      * \return True if \a tf passes all non-isolation filters.
      */
     bool passesNonIsolationFilters(TaggedFile* tf) const;
-
-    /*! \brief Enables or disables the untagged-only filter and re-applies the filter.
-     *
-     * When enabled, only files with no tags pass. When disabled, all files are eligible.
-     *
-     * \param untaggedOnly True to show only untagged files; false to disable the filter.
-     */
-    void setUntaggedOnly(bool untaggedOnly);
-
-    /*! \brief Returns true when the untagged-only filter is active.
-     *
-     * \return True if only untagged files are shown.
-     */
-    bool isUntaggedOnly() const;
 
 };
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -957,10 +957,6 @@ void MainWindow::on_actionClearAllFilters_triggered()
     // Isolation sets
     clearSelectionIsolation();
 
-    // Untagged-only filter
-    ui->actionUntaggedImages->setChecked(false);
-    core->setUntaggedOnly(false);
-
     refreshTagAssignmentArea();
 }
 
@@ -973,11 +969,18 @@ void MainWindow::on_actionUnreadableFiles_triggered()
     refreshTagAssignmentArea();
 }
 
-/*! \brief Toggles the untagged-only filter to show only files with no tags. */
+/*! \brief Captures all currently untagged files into the isolation set. */
 void MainWindow::on_actionUntaggedImages_triggered()
 {
-    bool active = ui->actionUntaggedImages->isChecked();
-    core->setUntaggedOnly(active);
+    QSet<TaggedFile*> untagged;
+    QStandardItemModel* model = core->getItemModel();
+    for (int row = 0; row < model->rowCount(); ++row) {
+        TaggedFile* tf = model->item(row)->data(Qt::UserRole + 1).value<TaggedFile*>();
+        if (tf && tf->tags()->isEmpty())
+            untagged.insert(tf);
+    }
+    core->setIsolationSet(untagged);
+    ui->actionClearIsolation->setEnabled(true);
     updateFileCountLabel();
     refreshTagAssignmentArea();
 }

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1075,9 +1075,6 @@
    </property>
   </action>
   <action name="actionUntaggedImages">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
    <property name="text">
     <string>Untagged Images</string>
    </property>


### PR DESCRIPTION
Revises the Untagged Images filter to use the existing isolation set mechanism. Each invocation captures a snapshot of all currently untagged files into the isolation set, so the user can tag files freely without them disappearing. Only on the next invocation does the set refresh.

Closes #12

Generated with [Claude Code](https://claude.ai/code)